### PR TITLE
Add generic CSV generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains the description and materials regarding the content gen
 Every dataset corresponds to a name graph that can later on be accessed in the triple store. Datasets may consist of more than one data file since they might have been further expanded over time or may contain different data components. 
 
 Users can download JudaicaLink datasets from the webpage of JudaicaLink . The datasets can also be browsed as Linked Open Data using Pubby (with DM2E extensions) as Web Frontend. Furthermore, a public SPARQL endpoint is available.
+A generic CSV generator is available in `csv-generator` for converting CSV data based on a JSON or TOML mapping using the `rdf_generator` library.
 
 
 

--- a/csv-generator/README.md
+++ b/csv-generator/README.md
@@ -1,0 +1,20 @@
+# Generic CSV Generator
+
+This generator converts CSV data into RDF using a mapping file. The mapping can be provided in JSON or TOML format and describes which columns of the CSV file correspond to which ontology properties. The conversion relies on the [`rdf_generator`](https://github.com/judaicalink/rdf_generator) library.
+
+## Usage
+
+Install the requirements listed in the repository and install the `rdf_generator` library:
+
+```bash
+pip install -r ../../requirements.txt
+pip install git+https://github.com/judaicalink/rdf_generator
+```
+
+Run the generator by providing a mapping file, a CSV input file and the name of the output file:
+
+```bash
+python generator.py mapping.toml input.csv output.ttl
+```
+
+The resulting Turtle file will be written to the provided output path.

--- a/csv-generator/generator.py
+++ b/csv-generator/generator.py
@@ -1,0 +1,38 @@
+import argparse
+import json
+import toml
+
+try:
+    from rdf_generator.generators.csv_generator import CsvGenerator
+except ImportError as e:
+    raise ImportError(
+        "rdf_generator package is required. Install it via 'pip install git+https://github.com/judaicalink/rdf_generator'"
+    ) from e
+
+
+def load_mapping(path: str):
+    """Load mapping from JSON or TOML file."""
+    if path.endswith(".json"):
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    if path.endswith(".toml"):
+        with open(path, "r", encoding="utf-8") as f:
+            return toml.load(f)
+    raise ValueError("Mapping file must be JSON or TOML")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate RDF from CSV using a mapping file")
+    parser.add_argument("mapping", help="Path to mapping file (.json or .toml)")
+    parser.add_argument("csv", help="Input CSV file")
+    parser.add_argument("output", help="Output Turtle file")
+    args = parser.parse_args()
+
+    mapping = load_mapping(args.mapping)
+    generator = CsvGenerator(mapping)
+    generator.generate(args.csv)
+    generator.graph.serialize(destination=args.output, format="turtle")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,3 +55,4 @@ tzdata
 urllib3
 wasabi
 weasel
+rdf_generator @ git+https://github.com/judaicalink/rdf_generator


### PR DESCRIPTION
## Summary
- add csv-generator module using `rdf_generator` library
- document setup and usage
- mention new generator in main README
- add `rdf_generator` dependency to requirements

## Testing
- `python -m py_compile csv-generator/generator.py`

------
https://chatgpt.com/codex/tasks/task_e_68405fb505f88330bba5cadc1b3da411