### PR TITLE
Rewrite encyclopedia converters

### DIFF
--- a/yivo-rujen-djh-macmillan/README.md
+++ b/yivo-rujen-djh-macmillan/README.md
@@ -1,4 +1,19 @@
 judaicalink-crawler
 ===================
 
-Crawler and RDF converter implementations for JudaicaLink
+This directory contains simple converters for the YIVO, RUJEN and DJH
+encyclopedias. The original CoffeeScript implementation has been
+replaced by Python scripts using `rdflib`.
+
+Each script reads the JSON exported by the crawler and writes a Turtle
+file with the corresponding RDF data. Concepts are linked to their
+encyclopedia specific concept scheme via `skos:inScheme` and each
+scheme is described explicitly in the output.
+
+Usage examples:
+
+```
+python yivo_json_to_rdf.py output.json yivo.ttl
+python rujen_json_to_rdf.py rujen.json rujen.ttl
+python djh_json_to_rdf.py djh.json djh.ttl
+```

--- a/yivo-rujen-djh-macmillan/djh_json_to_rdf.py
+++ b/yivo-rujen-djh-macmillan/djh_json_to_rdf.py
@@ -1,0 +1,76 @@
+import json
+from rdflib import Graph, Namespace, URIRef, Literal
+from rdflib.namespace import RDF, RDFS, SKOS, DCTERMS, FOAF
+
+JL = Namespace("http://data.judaicalink.org/ontology/")
+
+SCHEME_URI = URIRef("http://data.judaicalink.org/data/djh")
+SOURCE_URI = URIRef("http://dasjuedischehamburg.de/")
+
+
+def local(uri: str) -> URIRef:
+    return URIRef(uri.replace(
+        "http://dasjuedischehamburg.de/inhalt/",
+        "http://data.judaicalink.org/data/djh/",
+    ))
+
+
+def create_graph(records: list) -> Graph:
+    g = Graph()
+    g.bind("skos", SKOS)
+    g.bind("dcterms", DCTERMS)
+    g.bind("foaf", FOAF)
+    g.bind("rdfs", RDFS)
+    g.bind("jl", JL)
+
+    g.add((SCHEME_URI, RDF.type, SKOS.ConceptScheme))
+    g.add((SCHEME_URI, RDFS.label, Literal("Das J\u00fcdische Hamburg", lang="de")))
+    g.add((SCHEME_URI, DCTERMS.source, SOURCE_URI))
+
+    for record in records:
+        uri = local(record["uri"])
+        g.add((uri, RDF.type, SKOS.Concept))
+        if record.get("isPerson"):
+            g.add((uri, RDF.type, FOAF.Person))
+            if record.get("occupation"):
+                g.add((uri, JL.occupation, Literal(record["occupation"], lang="de")))
+            if record.get("birthDate"):
+                g.add((uri, JL.birthDate, Literal(record["birthDate"], lang="de")))
+            if record.get("birthLocation"):
+                g.add((uri, JL.birthLocation, Literal(record["birthLocation"], lang="de")))
+            if record.get("deathDate"):
+                g.add((uri, JL.deathDate, Literal(record["deathDate"], lang="de")))
+            if record.get("deathLocation"):
+                g.add((uri, JL.deathLocation, Literal(record["deathLocation"], lang="de")))
+        g.add((uri, JL.describedAt, URIRef(record["uri"])))
+        g.add((uri, SKOS.prefLabel, Literal(record.get("title"))))
+        g.add((uri, SKOS.inScheme, SCHEME_URI))
+
+        for l in record.get("links", []):
+            target = local(l["href"])
+            g.add((uri, SKOS.related, target))
+            if l.get("text"):
+                g.add((target, SKOS.altLabel, Literal(l["text"])))
+
+        if record.get("abstract"):
+            g.add((uri, JL.hasAbstract, Literal(record["abstract"], lang="de")))
+
+    return g
+
+
+def main(input_path: str = "djh.json", output_path: str = "djh.ttl") -> None:
+    with open(input_path, "r", encoding="utf-8") as f:
+        records = json.load(f)
+
+    graph = create_graph(records)
+    graph.serialize(destination=output_path, format="turtle")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Convert DJH JSON to RDF")
+    parser.add_argument("input", nargs="?", default="djh.json", help="Input JSON file")
+    parser.add_argument("output", nargs="?", default="djh.ttl", help="Output Turtle file")
+    args = parser.parse_args()
+    main(args.input, args.output)

--- a/yivo-rujen-djh-macmillan/rujen_json_to_rdf.py
+++ b/yivo-rujen-djh-macmillan/rujen_json_to_rdf.py
@@ -1,0 +1,100 @@
+import json
+from urllib.parse import unquote
+from rdflib import Graph, Namespace, URIRef, Literal
+from rdflib.namespace import RDF, RDFS, SKOS, DCTERMS, FOAF
+
+JL = Namespace("http://data.judaicalink.org/ontology/")
+
+SCHEME_URI = URIRef("http://data.judaicalink.org/data/rujen")
+SOURCE_URI = URIRef("http://www.rujen.ru/")
+
+latin_substitution = [
+    "a", "b", "v", "g", "d", "e", "zh", "z", "i", "y",
+    "k", "l", "m", "n", "o", "p", "r", "s", "t", "u",
+    "f", "kh", "ts", "ch", "sh", "shch", "j", "y", "j", "e",
+    "yu", "ya", "e", "e",
+]
+UTF8_BEGIN = 1072
+
+
+def transliterate(text: str) -> str:
+    result = ""
+    for ch in text.lower():
+        code = ord(ch) - UTF8_BEGIN
+        if 0 <= code < len(latin_substitution):
+            result += latin_substitution[code]
+        else:
+            result += ch
+    return result
+
+
+def local(uri: str) -> URIRef:
+    replaced = unquote(uri).replace(
+        "http://rujen.ru/index.php/",
+        "http://data.judaicalink.org/data/rujen/",
+    )
+    return URIRef(transliterate(replaced))
+
+
+def create_graph(records: list) -> Graph:
+    g = Graph()
+    g.bind("skos", SKOS)
+    g.bind("dcterms", DCTERMS)
+    g.bind("foaf", FOAF)
+    g.bind("rdfs", RDFS)
+    g.bind("jl", JL)
+
+    g.add((SCHEME_URI, RDF.type, SKOS.ConceptScheme))
+    g.add((SCHEME_URI, RDFS.label, Literal("Russian Jewish Encyclopedia", lang="en")))
+    g.add((SCHEME_URI, DCTERMS.source, SOURCE_URI))
+
+    for record in records:
+        uri = local(record["uri"])
+        g.add((uri, RDF.type, SKOS.Concept))
+        g.add((uri, SKOS.prefLabel, Literal(record.get("title"))))
+        g.add((uri, JL.describedAt, URIRef(record["uri"])))
+        g.add((uri, SKOS.inScheme, SCHEME_URI))
+        g.add((uri, DCTERMS.identifier, Literal(unquote(record["uri"].split("index.php/")[-1]))))
+
+        for l in record.get("links", []) or []:
+            target = local(l["href"])
+            g.add((uri, SKOS.related, target))
+            if l.get("text"):
+                g.add((target, SKOS.altLabel, Literal(l["text"])))
+
+        for cat in record.get("categories", []) or []:
+            if cat == "\u041f\u0435\u0440\u0441\u043e\u043d\u0430\u043b\u0438\u0438":
+                g.add((uri, JL.hasCategory, URIRef("http://data.judaicalink.org/data/rujen/person")))
+            elif cat == "\u0413\u0435\u043e\u0433\u0440\u0430\u0444\u0438\u044f":
+                g.add((uri, JL.hasCategory, URIRef("http://data.judaicalink.org/data/rujen/geography")))
+
+        if record.get("abstract"):
+            g.add((uri, JL.hasAbstract, Literal(record["abstract"], lang="ru")))
+
+        if record.get("empty"):
+            g.add(
+                (uri, SKOS.scopeNote, Literal(
+                    "The article describing this concept does not (yet) exist in the encyclopedia.",
+                    lang="en",
+                ))
+            )
+
+    return g
+
+
+def main(input_path: str = "rujen.json", output_path: str = "rujen.ttl") -> None:
+    with open(input_path, "r", encoding="utf-8") as f:
+        records = json.load(f)
+
+    graph = create_graph(records)
+    graph.serialize(destination=output_path, format="turtle")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Convert RUJEN JSON to RDF")
+    parser.add_argument("input", nargs="?", default="rujen.json", help="Input JSON file")
+    parser.add_argument("output", nargs="?", default="rujen.ttl", help="Output Turtle file")
+    args = parser.parse_args()
+    main(args.input, args.output)

--- a/yivo-rujen-djh-macmillan/yivo_json_to_rdf.py
+++ b/yivo-rujen-djh-macmillan/yivo_json_to_rdf.py
@@ -1,0 +1,80 @@
+import json
+from pathlib import Path
+from urllib.parse import unquote
+from rdflib import Graph, Namespace, URIRef, Literal
+from rdflib.namespace import RDF, RDFS, SKOS, DCTERMS, FOAF
+
+JL = Namespace("http://data.judaicalink.org/ontology/")
+
+SCHEME_URI = URIRef("http://data.judaicalink.org/data/yivo")
+SOURCE_URI = URIRef("http://www.yivoencyclopedia.org/")
+
+
+def local(uri: str) -> URIRef:
+    return URIRef(uri.replace(
+        "http://www.yivoencyclopedia.org/article.aspx/",
+        "http://data.judaicalink.org/data/yivo/",
+    ))
+
+
+def create_graph(records: list) -> Graph:
+    g = Graph()
+    g.bind("skos", SKOS)
+    g.bind("dcterms", DCTERMS)
+    g.bind("foaf", FOAF)
+    g.bind("rdfs", RDFS)
+    g.bind("jl", JL)
+
+    g.add((SCHEME_URI, RDF.type, SKOS.ConceptScheme))
+    g.add((SCHEME_URI, RDFS.label, Literal("YIVO Encyclopedia", lang="en")))
+    g.add((SCHEME_URI, DCTERMS.source, SOURCE_URI))
+
+    for record in records:
+        uri = local(record["uri"])
+        g.add((uri, RDF.type, SKOS.Concept))
+        g.add((uri, SKOS.prefLabel, Literal(record.get("title"))))
+        g.add((uri, JL.describedAt, URIRef(record["uri"])))
+        g.add((uri, SKOS.inScheme, SCHEME_URI))
+
+        for l in record.get("links", []):
+            target = local(l["href"])
+            g.add((uri, SKOS.related, target))
+            if l.get("text"):
+                g.add((target, SKOS.altLabel, Literal(l["text"])))
+
+        if record.get("abstract"):
+            g.add((uri, JL.hasAbstract, Literal(record["abstract"], lang="en")))
+
+        for sc in record.get("subconcepts", []):
+            sub_uri = URIRef(f"{uri}/{sc.replace(' ', '_')}")
+            g.add((sub_uri, RDF.type, SKOS.Concept))
+            g.add((sub_uri, SKOS.prefLabel, Literal(sc)))
+            g.add((sub_uri, SKOS.broader, uri))
+            g.add((sub_uri, SKOS.inScheme, SCHEME_URI))
+            g.add((uri, SKOS.narrower, sub_uri))
+
+        for sr in record.get("subrecords", []):
+            g.add((uri, SKOS.narrower, local(sr["href"])))
+
+        if record.get("broader"):
+            g.add((uri, SKOS.broader, local(record["broader"])))
+
+    return g
+
+
+def main(input_path: str = "output.json", output_path: str = "output.ttl") -> None:
+    with open(input_path, "r", encoding="utf-8") as f:
+        records = json.load(f)
+
+    graph = create_graph(records)
+    graph.serialize(destination=output_path, format="turtle")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Convert YIVO JSON to RDF")
+    parser.add_argument("input", nargs="?", default="output.json", help="Input JSON file")
+    parser.add_argument("output", nargs="?", default="output.ttl", help="Output Turtle file")
+    args = parser.parse_args()
+    main(args.input, args.output)


### PR DESCRIPTION
## Summary
- rewrite JSON-to-RDF converters in Python
- link concepts to a concept scheme via `skos:inScheme`
- describe the concept schemes in the RDF output
- document the new scripts

## Testing
- `python -m py_compile yivo-rujen-djh-macmillan/yivo_json_to_rdf.py`
- `python -m py_compile yivo-rujen-djh-macmillan/rujen_json_to_rdf.py`
- `python -m py_compile yivo-rujen-djh-macmillan/djh_json_to_rdf.py`


------
https://chatgpt.com/codex/tasks/task_e_68408c32e5748330817b64bc57c22925