### PR TITLE
Remove absolute paths

### DIFF
--- a/bhr/Round1/scripts/BHR-GND.py
+++ b/bhr/Round1/scripts/BHR-GND.py
@@ -14,7 +14,7 @@ import pprint
 import csv
 import sys
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")
 rdf = Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
@@ -25,10 +25,10 @@ owl = Namespace("http://www.w3.org/2002/07/owl#")
 
 
 g = Graph()
-g.parse('C:\Users\Maral\Desktop\Encyc.rdf', format="turtle")
+g.parse('Encyc.rdf', format='turtle')
 
 g2 = Graph()
-g2.parse('C:\Users\Maral\Desktop\EncycBHR-ID.rdf', format="turtle")
+g2.parse('EncycBHR-ID.rdf', format='turtle')
 
 
 g.bind('gndo',gndo)
@@ -130,6 +130,5 @@ for itemencyc in resultencyc:
 
 
 g.serialize(destination='EncycBHR-ID-GND.rdf', format="turtle")
-
 
 

--- a/bhr/Round1/scripts/BHR-vs-GND-01.py
+++ b/bhr/Round1/scripts/BHR-vs-GND-01.py
@@ -10,7 +10,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 
@@ -23,7 +23,7 @@ owl = Namespace("http://www.w3.org/2002/07/owl#")
 
 g = Graph()
 
-g.parse('C:\Users\Maral\Desktop\EncycBHR-ID-GND-JL.ttl', format="turtle")
+g.parse('EncycBHR-ID-GND-JL.ttl', format='turtle')
 
 
 g.bind('foaf',foaf)
@@ -82,4 +82,3 @@ if (u"a",u"city",u"x",u"z") in results:
        g.add( (URIRef(jluri), jl.birthLocation , Literal(city) ) )
 
 g.serialize(destination = 'EncycBHR-ID-GND-JL.ttl' , format="turtle")
-

--- a/bhr/Round1/scripts/BHR-vs-JudaicaLink-01.py
+++ b/bhr/Round1/scripts/BHR-vs-JudaicaLink-01.py
@@ -10,7 +10,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 
@@ -23,7 +23,7 @@ owl = Namespace("http://www.w3.org/2002/07/owl#")
 
 g = Graph()
 
-g.parse('C:\Users\Maral\Desktop\EncycBHR-ID-GND.ttl', format="turtle")
+g.parse('EncycBHR-ID-GND.ttl', format='turtle')
 
 
 g.bind('foaf',foaf)
@@ -84,4 +84,3 @@ if (u"a",u"x",u"z") in results:
        g.add( (URIRef(jluri), owl.sameAs , URIRef(uri) ) )
 
 g.serialize(destination = 'EncycBHR-ID-GND-JL.ttl' , format="turtle")
-

--- a/bhr/Round1/scripts/ContentExtraction.py
+++ b/bhr/Round1/scripts/ContentExtraction.py
@@ -14,7 +14,7 @@ import csv
 import re
 import unidecode
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 
 output = open('Encycoutput.csv','w')
@@ -34,7 +34,7 @@ graph.bind('Springer', Springer)
 graph.bind ('owl' , OWL)
 
 
-data = csv.reader(open('C:\\Users\\Maral\\Desktop\\new1-cleaned.csv'))
+data = csv.reader(open('new1-cleaned.csv'))
 fields = data.next()
 eventdic={}
 
@@ -212,4 +212,3 @@ output.close()
 
 
 #graph.serialize(destination='output5.rdf', format="turtle")
-

--- a/bhr/Round1/scripts/Encyc-to-RDF-ID.py
+++ b/bhr/Round1/scripts/Encyc-to-RDF-ID.py
@@ -14,7 +14,7 @@ import csv
 import re
 import unidecode
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 graph = Graph()
 
@@ -31,7 +31,7 @@ graph.bind('gndo',gndo)
 graph.bind ('owl' , owl)
 
 
-data = csv.reader(open('C:\\Users\\Maral\\Desktop\\BHR-ID.csv'))
+data = csv.reader(open('BHR-ID.csv'))
 fields = data.next()
 eventdic={}
 
@@ -109,5 +109,4 @@ for row in data:
     graph.add((URIRef(uri), skos.prefLabel,(Literal(names)) ))
 
 graph.serialize(destination='EncycBHR-ID.rdf', format="turtle")
-
 

--- a/bhr/Round1/scripts/Encyc-to-RDF.py
+++ b/bhr/Round1/scripts/Encyc-to-RDF.py
@@ -14,7 +14,7 @@ import csv
 import re
 import unidecode
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 graph = Graph()
 
@@ -31,7 +31,7 @@ graph.bind('gndo',gndo)
 graph.bind ('owl' , owl)
 
 
-data = csv.reader(open('C:\\Users\\Maral\\Desktop\\Encycoutput.csv'))
+data = csv.reader(open('Encycoutput.csv'))
 fields = data.next()
 eventdic={}
 
@@ -111,4 +111,3 @@ for row in data:
     graph.add((URIRef(uri), jl.occpation ,(URIRef('http://data.judaicalink.org/data/occupation/Rabbi')) ))
 
 graph.serialize(destination='Encyc.rdf', format="turtle")
-

--- a/bhr/Round1/scripts/Scrapping_Persons_01.py
+++ b/bhr/Round1/scripts/Scrapping_Persons_01.py
@@ -10,7 +10,7 @@ import os , glob
 import csv
 import re
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 output = open('BHR-ID.csv','w')
 

--- a/bhr/Round2/scripts/Entityfacts-01.py
+++ b/bhr/Round2/scripts/Entityfacts-01.py
@@ -13,7 +13,7 @@ import csv
 import re
 import time
 
-os.chdir('C:\\Users\\Maral\\Desktop')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 

--- a/bhr/Round2/scripts/Integrate-new-old-02.py
+++ b/bhr/Round2/scripts/Integrate-new-old-02.py
@@ -10,7 +10,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML , RDF , JSON
 from rdflib.namespace import RDF, FOAF , SKOS ,RDFS
 import os
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 #sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 
@@ -24,7 +24,7 @@ dc = Namespace ("http://purl.org/dc/elements/1.1/")
 
 graph= Graph()
 
-graph.parse('C:\\Users\\Maral\\Desktop\\bhr-new-enrich.rdf', format="turtle")
+graph.parse('bhr-new-enrich.rdf', format='turtle')
 
 
 spar= """
@@ -67,8 +67,8 @@ for item in results:
 
 graph2= Graph()
 
-#graph2.parse('C:\Users\Maral\Desktop\EncycBHR-ID-GND-JL.ttl', format="turtle")
-graph2.parse('C:\\Users\\Maral\\Desktop\\bhr-final.ttl', format="turtle")
+#graph2.parse('EncycBHR-ID-GND-JL.ttl', format='turtle')
+graph2.parse('bhr-final.ttl', format='turtle')
 
 
 
@@ -132,7 +132,6 @@ for item in results:
 
 #graph2.serialize(destination='bhr-final.ttl', format="turtle")
 graph2.serialize(destination='bhr-final-02.ttl', format="turtle")
-
 
 
 

--- a/bhr/Round2/scripts/Integrate-new-old-03.py
+++ b/bhr/Round2/scripts/Integrate-new-old-03.py
@@ -10,7 +10,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML , RDF , JSON
 from rdflib.namespace import RDF, FOAF , SKOS ,RDFS
 import os
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 #sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 
@@ -24,7 +24,7 @@ dc = Namespace ("http://purl.org/dc/elements/1.1/")
 
 graph= Graph()
 
-graph.parse('C:\\Users\\Maral\\Desktop\\bhr-new-enrich.rdf', format="turtle")
+graph.parse('bhr-new-enrich.rdf', format='turtle')
 
 dicsame = {}
 
@@ -64,8 +64,8 @@ results = graph.query(spar)
 
 graph2= Graph()
 
-#graph2.parse('C:\\Users\\Maral\\Desktop\\bhr-final-02.ttl', format="turtle")
-graph2.parse('C:\\Users\\Maral\\Desktop\\bhr-final-03.ttl', format="turtle")
+#graph2.parse('bhr-final-02.ttl', format='turtle')
+graph2.parse('bhr-final-03.ttl', format='turtle')
 
 
 graph2.bind('foaf',foaf)
@@ -125,5 +125,4 @@ for item2 in results2:
 
 #graph2.serialize(destination='bhr-final-03.ttl', format="turtle")
 graph2.serialize(destination='bhr-final-04.ttl', format="turtle")
-
 

--- a/bhr/Round2/scripts/Integrate-new-old-04.py
+++ b/bhr/Round2/scripts/Integrate-new-old-04.py
@@ -10,7 +10,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML , RDF , JSON
 from rdflib.namespace import RDF, FOAF , SKOS ,RDFS
 import os
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 #sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 
@@ -24,7 +24,7 @@ dc = Namespace ("http://purl.org/dc/elements/1.1/")
 
 graph= Graph()
 
-graph.parse('C:\\Users\\Maral\\Desktop\\bhr-new-enrich.rdf', format="turtle")
+graph.parse('bhr-new-enrich.rdf', format='turtle')
 
 
 dicsame = {}
@@ -63,7 +63,7 @@ results = graph.query(spar)
 
 graph2= Graph()
 
-graph2.parse('C:\\Users\\Maral\\Desktop\\bhr-final-04.ttl', format="turtle")
+graph2.parse('bhr-final-04.ttl', format='turtle')
 
 
 graph2.bind('foaf',foaf)
@@ -115,6 +115,5 @@ for item2 in results2:
                 graph2.add((URIRef(uri) , owl.sameAs , URIRef(same)))
 
 graph2.serialize(destination='bhr-final-05.ttl', format="turtle")
-
 
 

--- a/bhr/Round2/scripts/Scrapping_Persons_03.py
+++ b/bhr/Round2/scripts/Scrapping_Persons_03.py
@@ -10,7 +10,7 @@ import os , glob
 import csv
 import re
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")
 skos = Namespace("http://www.w3.org/2004/02/skos/core#")
@@ -196,7 +196,6 @@ for i in range (1 , 2704):
 
 
 graph.serialize(destination='bhr-new-enrich.rdf', format="turtle")
-
 
 
 

--- a/dbpedia-persons/scripts/Entityfacts-01.py
+++ b/dbpedia-persons/scripts/Entityfacts-01.py
@@ -13,7 +13,7 @@ import csv
 import re
 import time
 
-os.chdir('C:\\Users\\Maral\\Desktop')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 
@@ -104,4 +104,3 @@ for i in range(0,len(results.bindings)):
 #graph.serialize(destination='Entityfacts-freimann-sameas.ttl', format="turtle")
 #graph.serialize(destination='Entityfacts-gnd-sameas.ttl', format="turtle")
 graph.serialize(destination='Entityfacts-ubgnd-sameas.ttl', format="turtle")
-#graph.serialize(destination='Entityfacts-bhr-sameas.ttl', format="turtle")

--- a/dbpedia-persons/scripts/generated_persons_DBPedia_enrich.py
+++ b/dbpedia-persons/scripts/generated_persons_DBPedia_enrich.py
@@ -9,7 +9,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML , RDF , JSON
 from rdflib.namespace import RDF, FOAF , SKOS ,RDFS
 import os
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 
@@ -21,9 +21,9 @@ owl = Namespace ("http://www.w3.org/2002/07/owl#")
 
 graphuni = Graph()
 
-#graphuni.parse('C:\Users\Maral\Desktop\generated_person_dbpedia_modified_gnd.ttl', format="turtle")
-#graphuni.parse('C:\Users\Maral\Desktop\generated_persons_DBPedia-enriched-01.ttl', format="turtle")
-graphuni.parse('C:\Users\Maral\Desktop\generated_persons_DBPedia-enriched-02.ttl', format="turtle")
+#graphuni.parse("generated_person_dbpedia_modified_gnd.ttl", format="turtle")
+#graphuni.parse("generated_persons_DBPedia-enriched-01.ttl", format="turtle")
+graphuni.parse('generated_persons_DBPedia-enriched-02.ttl', format="turtle")
 
 
 

--- a/dbpedia-persons/scripts/gndid_generator.py
+++ b/dbpedia-persons/scripts/gndid_generator.py
@@ -10,7 +10,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop\output')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("https://query.wikidata.org/sparql")
 
@@ -69,7 +69,7 @@ def generator_gndid (URI):
 
 
 g = Graph()
-g.parse('C:\Users\Maral\Desktop\generated_person\generated_person.rdf', format="turtle")
+g.parse('generated_person/generated_person.rdf', format="turtle")
 
 #this query will extract only the sameAs links to Wikidata
 

--- a/dbpedia-persons/scripts/person_generator_DBPedia.py
+++ b/dbpedia-persons/scripts/person_generator_DBPedia.py
@@ -11,11 +11,11 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop\generated_persons')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://dbpedia.org/sparql")
 
-path = 'C:\Users\Maral\Desktop' #adapted to the list file path
+path = '.' #adapted to the list file path
 
 graph = Graph()
 
@@ -102,7 +102,7 @@ def generator_person (URI ,OccURI):
     return
 
 g = Graph()
-g.parse('C:\Users\Maral\Desktop\generated_persons\occ_ontology.rdf', format="turtle")
+g.parse('generated_persons/occ_ontology.rdf', format="turtle")
 
 
 spar= """

--- a/dbpedia-persons/scripts/person_generator_DBPedia_modify.py
+++ b/dbpedia-persons/scripts/person_generator_DBPedia_modify.py
@@ -11,9 +11,9 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
-path = 'C:\Users\Maral\Desktop' #adapted to the list file path
+path = '.' #adapted to the list file path
 
 graph = Graph()
 
@@ -34,7 +34,7 @@ graph.bind('skos',skos)
 
 
 g = Graph()
-g.parse('C:\Users\Maral\Desktop\generated_person_dbpedia.ttl', format="turtle")
+g.parse('generated_person_dbpedia.ttl', format="turtle")
 
 
 spar= """

--- a/dbpedia-persons/scripts/person_generator_DBPedia_modify_gnd.py
+++ b/dbpedia-persons/scripts/person_generator_DBPedia_modify_gnd.py
@@ -11,9 +11,9 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
-path = 'C:\Users\Maral\Desktop' #adapted to the list file path
+path = '.' #adapted to the list file path
 
 
 
@@ -29,11 +29,11 @@ owl = Namespace("http://www.w3.org/2002/07/owl#")
 
 
 g2 = Graph()
-g2.parse('C:\Users\Maral\Desktop\person-gndid.ttl', format="turtle")
+g2.parse('person-gndid.ttl', format="turtle")
 
 
 g = Graph()
-g.parse('C:\Users\Maral\Desktop\generated_person_dbpedia_modified.ttl', format="turtle")
+g.parse('generated_person_dbpedia_modified.ttl', format="turtle")
 
 g.bind('jl', jl)
 g.bind('owl',OWL)

--- a/fid-judaica/compactmemory/Scripts/CM-contex-GND-multi-02.py
+++ b/fid-judaica/compactmemory/Scripts/CM-contex-GND-multi-02.py
@@ -12,9 +12,9 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
-path = 'C:\Users\Maral\Desktop' #adapted to the list file path
+path = script_dir  # adapted to the list file path
 
 graphout = Graph()
 graphno=Graph()
@@ -50,7 +50,7 @@ graphno.bind('edm',edm)
 
 
 graph = Graph()
-graph.parse('C:\Users\Maral\Desktop\cm-gnd-multi.rdf', format="turtle")
+graph.parse(os.path.join(script_dir, 'cm-gnd-multi.rdf'), format="turtle")
 
 
 
@@ -91,7 +91,7 @@ print gndname
 
 
 g = Graph()
-g.parse('C:\Users\Maral\Desktop\compact-extracted-02.rdf', format="turtle")
+g.parse(os.path.join(script_dir, 'compact-extracted-02.rdf'), format="turtle")
 
 spar= """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/fid-judaica/compactmemory/Scripts/CM-contex-GND-uni-02.py
+++ b/fid-judaica/compactmemory/Scripts/CM-contex-GND-uni-02.py
@@ -12,9 +12,9 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
-path = 'C:\Users\Maral\Desktop' #adapted to the list file path
+path = script_dir  # adapted to the list file path
 
 graphout = Graph()
 graphno=Graph()
@@ -50,7 +50,7 @@ graphno.bind('edm',edm)
 
 
 graph = Graph()
-graph.parse('C:\Users\Maral\Desktop\cm-gnd-uni.rdf', format="turtle")
+graph.parse(os.path.join(script_dir, 'cm-gnd-uni.rdf'), format="turtle")
 
 
 
@@ -90,7 +90,7 @@ print gndname
 
 
 g = Graph()
-g.parse('C:\Users\Maral\Desktop\compact-extracted-02.rdf', format="turtle")
+g.parse(os.path.join(script_dir, 'compact-extracted-02.rdf'), format="turtle")
 
 spar= """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/fid-judaica/compactmemory/Scripts/CM-multi-name-filter.py
+++ b/fid-judaica/compactmemory/Scripts/CM-multi-name-filter.py
@@ -12,7 +12,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\\Users\\Maral\\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
 graphout = Graph()
 
@@ -35,7 +35,7 @@ graphout.bind('edm',edm)
 
 
 graph = Graph()
-graph.parse('C:\\Users\\Maral\\Desktop\\cm-authors-context-GND-multi-02.rdf', format="turtle")
+graph.parse(os.path.join(script_dir, 'cm-authors-context-GND-multi-02.rdf'), format="turtle")
 
 
 

--- a/fid-judaica/compactmemory/Scripts/CM-uni-name-filter-complete.py
+++ b/fid-judaica/compactmemory/Scripts/CM-uni-name-filter-complete.py
@@ -12,7 +12,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\\Users\\Maral\\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
 graphout = Graph()
 
@@ -38,7 +38,7 @@ graphout.bind('edm',edm)
 
 graph = Graph()
 
-graph.parse('C:\\Users\\Maral\\Desktop\\cm-authors-uni-date-filtered.ttl', format="turtle")
+graph.parse(os.path.join(script_dir, 'cm-authors-uni-date-filtered.ttl'), format="turtle")
 
 
 urilist = []
@@ -77,7 +77,7 @@ for ubitem in result: #names from UB Freimann
 
 
 g = Graph()
-g.parse('C:\\Users\\Maral\\Desktop\\cm-uni-names-filtered.ttl', format="turtle")
+g.parse(os.path.join(script_dir, 'cm-uni-names-filtered.ttl'), format="turtle")
 
 spar= """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/fid-judaica/compactmemory/Scripts/CM-uni-name-filter.py
+++ b/fid-judaica/compactmemory/Scripts/CM-uni-name-filter.py
@@ -12,7 +12,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\\Users\\Maral\\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
 graphout = Graph()
 
@@ -35,7 +35,7 @@ graphout.bind('edm',edm)
 
 
 graph = Graph()
-graph.parse('C:\\Users\\Maral\\Desktop\\cm-authors-context-GND-uni-02.rdf', format="turtle")
+graph.parse(os.path.join(script_dir, 'cm-authors-context-GND-uni-02.rdf'), format="turtle")
 
 
 

--- a/fid-judaica/compactmemory/Scripts/No-GND.py
+++ b/fid-judaica/compactmemory/Scripts/No-GND.py
@@ -9,7 +9,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML , RDF , JSON
 from rdflib.namespace import RDF, FOAF , SKOS ,RDFS, OWL
 import os
 
-os.chdir('C:\Users\Maral\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 
@@ -35,7 +35,7 @@ graphout.bind('dc',dc)
 graphout.bind('edm',edm)
 
 graph1 = Graph()
-graph1.parse('C:\Users\Maral\Desktop\cm-gnd-uni.rdf', format="turtle")
+graph1.parse(os.path.join(script_dir, 'cm-gnd-uni.rdf'), format="turtle")
 
 unilist=[]
 
@@ -72,7 +72,7 @@ for item in result:
     unilist.append(item[1].value.encode('utf-8'))
 
 graph2= Graph()
-graph2.parse('C:\Users\Maral\Desktop\cm-gnd-multi.rdf', format="turtle")
+graph2.parse(os.path.join(script_dir, 'cm-gnd-multi.rdf'), format="turtle")
 
 multilist=[]
 

--- a/fid-judaica/compactmemory/Scripts/cm-Date-filtering.py
+++ b/fid-judaica/compactmemory/Scripts/cm-Date-filtering.py
@@ -9,7 +9,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML , RDF , JSON , TURTLE
 from rdflib.namespace import RDF, FOAF , SKOS ,RDFS
 import os
 
-os.chdir('C:\Users\Maral\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
 
 #output = open('date.csv','w')

--- a/fid-judaica/compactmemory/Scripts/compact-extarction-02.py
+++ b/fid-judaica/compactmemory/Scripts/compact-extarction-02.py
@@ -9,7 +9,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML , RDF , JSON
 from rdflib.namespace import RDF, FOAF , SKOS ,RDFS
 import os
 
-os.chdir('C:\Users\Maral\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 

--- a/fid-judaica/freimann/scripts/Not-in-GND.py
+++ b/fid-judaica/freimann/scripts/Not-in-GND.py
@@ -8,7 +8,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML , RDF , JSON
 from rdflib.namespace import RDF, FOAF , SKOS ,RDFS
 import os
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 

--- a/fid-judaica/freimann/scripts/Tn-GNDID-01.py
+++ b/fid-judaica/freimann/scripts/Tn-GNDID-01.py
@@ -9,7 +9,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML , RDF , JSON
 from rdflib.namespace import RDF, FOAF , SKOS ,RDFS
 import os
 
-os.chdir('C:\Users\Maral\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 

--- a/fid-judaica/freimann/scripts/Tn-GNDID-02.py
+++ b/fid-judaica/freimann/scripts/Tn-GNDID-02.py
@@ -9,7 +9,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML , RDF , JSON
 from rdflib.namespace import RDF, FOAF , SKOS ,RDFS
 import os
 
-os.chdir('C:\Users\Maral\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 

--- a/fid-judaica/freimann/scripts/Tn-GNDID-03.py
+++ b/fid-judaica/freimann/scripts/Tn-GNDID-03.py
@@ -10,7 +10,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML , RDF , JSON
 from rdflib.namespace import RDF, FOAF , SKOS ,RDFS
 import os
 
-os.chdir('C:\Users\Maral\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 

--- a/fid-judaica/freimann/scripts/Tn-contex-GND-multi.py
+++ b/fid-judaica/freimann/scripts/Tn-contex-GND-multi.py
@@ -12,9 +12,9 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
-path = 'C:\Users\Maral\Desktop' #adapted to the list file path
+path = script_dir  # adapted to the list file path
 
 graphout = Graph()
 
@@ -38,7 +38,7 @@ graphout.bind('edm',edm)
 
 
 graph = Graph()
-graph.parse('C:\Users\Maral\Desktop\Tn-gnd-multi-2.rdf', format="turtle")
+graph.parse(os.path.join(script_dir, 'Tn-gnd-multi-2.rdf'), format="turtle")
 
 
 
@@ -75,7 +75,7 @@ result = graph.query(spar1)
 
 
 g = Graph()
-g.parse('C:\Users\Maral\Desktop\Tn-authors.ttl', format="turtle")
+g.parse(os.path.join(script_dir, 'Tn-authors.ttl'), format="turtle")
 
 spar= """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/fid-judaica/freimann/scripts/Tn-contex-GND-uni.py
+++ b/fid-judaica/freimann/scripts/Tn-contex-GND-uni.py
@@ -12,9 +12,9 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
-path = 'C:\Users\Maral\Desktop' #adapted to the list file path
+path = script_dir  # adapted to the list file path
 
 graphout = Graph()
 
@@ -38,7 +38,7 @@ graphout.bind('edm',edm)
 
 
 graph = Graph()
-graph.parse('C:\Users\Maral\Desktop\Tn-gnd-uni.rdf', format="turtle")
+graph.parse(os.path.join(script_dir, 'Tn-gnd-uni.rdf'), format="turtle")
 
 
 
@@ -75,7 +75,7 @@ result = graph.query(spar1)
 
 
 g = Graph()
-g.parse('C:\Users\Maral\Desktop\Tn-authors.ttl', format="turtle")
+g.parse(os.path.join(script_dir, 'Tn-authors.ttl'), format="turtle")
 
 spar= """
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/fid-judaica/haskala/scripts/CSV-to-RDF-Haskala.py
+++ b/fid-judaica/haskala/scripts/CSV-to-RDF-Haskala.py
@@ -13,7 +13,7 @@ import csv
 import re
 from urllib import request , parse
 
-os.chdir('C:\\Users\\Maral\\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
 graph = Graph()
 
@@ -103,7 +103,7 @@ def generator_persons (newuri):
     return (jluri)
 
 
-data = csv.reader(open('C:\\Users\\Maral\\Desktop\\Assignments responsible persons_Maral.csv'))
+data = csv.reader(open(os.path.join(script_dir, 'Assignments responsible persons_Maral.csv')))
 
 for row in data:
 

--- a/fid-judaica/haskala/scripts/CSV-to-RDF-Haskalanet.py
+++ b/fid-judaica/haskala/scripts/CSV-to-RDF-Haskalanet.py
@@ -12,8 +12,7 @@ import os , glob
 import csv
 import re
 
-os.chdir('C:\\Users\\Maral\\Desktop')
-
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 graph = Graph()
 graphex = Graph()
 
@@ -42,7 +41,7 @@ graphex.bind ('owl' , owl)
 graphex.bind('edm',edm)
 graphex.bind('dc',dc)
 
-data = csv.reader(open('C:\\Users\\Maral\\Desktop\\haskalanet_01.csv'))
+data = csv.reader(open(os.path.join(script_dir, 'haskalanet_01.csv')))
 
 for row in data:
 

--- a/fid-judaica/haskala/scripts/GND-enrich-02.py
+++ b/fid-judaica/haskala/scripts/GND-enrich-02.py
@@ -9,7 +9,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML , RDF , JSON
 from rdflib.namespace import RDF, FOAF , SKOS ,RDFS
 import os
 
-os.chdir('C:\\Users\\Maral\\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 

--- a/geocoordinates/scripts/Locaion-coor-03.py
+++ b/geocoordinates/scripts/Locaion-coor-03.py
@@ -21,7 +21,7 @@ geo = Namespace("http://www.opengis.net/ont/geosparql#")
 
 
 graph=Graph()
-graph.parse('C:\Users\Maral\Desktop\city-geocoor-04-all.ttl', format="turtle")
+graph.parse('city-geocoor-04-all.ttl', format="turtle")
 
 graph1=Graph()
 graph2=Graph()

--- a/gnd-persons/scripts/Entityfacts-01.py
+++ b/gnd-persons/scripts/Entityfacts-01.py
@@ -13,7 +13,7 @@ import csv
 import re
 import time
 
-os.chdir('C:\\Users\\Maral\\Desktop')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 

--- a/gnd-persons/scripts/Freimann-GND-enrich.py
+++ b/gnd-persons/scripts/Freimann-GND-enrich.py
@@ -9,7 +9,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML , RDF , JSON
 from rdflib.namespace import RDF, FOAF , SKOS ,RDFS
 import os
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 
@@ -20,11 +20,11 @@ jl = Namespace("http://data.judaicalink.org/ontology/")
 owl = Namespace ("http://www.w3.org/2002/07/owl#")
 
 graphuni = Graph()
-#graphuni.parse('C:\Users\Maral\Desktop\Freimann-GND-03.rdf', format="turtle") #first the original file is enriched only with those which have altlabels and occ in GND.
-#graphuni.parse('C:\Users\Maral\Desktop\Freimann-GND-enriched-01.ttl', format="turtle") #then the generated file is parsed again to add further information like date and place of birth and death.
-#graphuni.parse('C:\Users\Maral\Desktop\Freimann-GND-enriched-02.ttl', format="turtle") #to extarct only those which have date of birth and death with out the place
-#graphuni.parse('C:\Users\Maral\Desktop\Freimann-GND-enriched-03.ttl', format="turtle") #to extarct only those which have no alt lable but date of birth and death
-graphuni.parse('C:\Users\Maral\Desktop\Freimann-GND-enriched-04.ttl', format="turtle") #to extarct only those which have no alt lable and no occ and no date of death but date of birth.
+#graphuni.parse('Freimann-GND-03.rdf', format="turtle") #first the original file is enriched only with those which have altlabels and occ in GND.
+#graphuni.parse('Freimann-GND-enriched-01.ttl', format="turtle") #then the generated file is parsed again to add further information like date and place of birth and death.
+#graphuni.parse('Freimann-GND-enriched-02.ttl', format="turtle") #to extarct only those which have date of birth and death with out the place
+#graphuni.parse('Freimann-GND-enriched-03.ttl', format="turtle") #to extarct only those which have no alt lable but date of birth and death
+graphuni.parse('Freimann-GND-enriched-04.ttl', format="turtle") #to extarct only those which have no alt lable and no occ and no date of death but date of birth.
 
 
 
@@ -132,7 +132,6 @@ if (u"x",u"label",u"id",u"y",u"birth") in results: #fifth round
 #graphuni.serialize(destination='Freimann-GND-enriched-03.ttl', format="turtle") #the third generated file
 #graphuni.serialize(destination='Freimann-GND-enriched-04.ttl', format="turtle") #the fourth generated file
 graphuni.serialize(destination='Freimann-GND-enriched-05.ttl', format="turtle") #the fourth generated file
-
 
 
 

--- a/gnd-persons/scripts/UB-gnd.py
+++ b/gnd-persons/scripts/UB-gnd.py
@@ -14,7 +14,7 @@ import csv
 import re
 import unidecode
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
@@ -140,7 +140,7 @@ def generator_gnd (gndURI):
     return
 
 
-data = csv.reader(open('C:\\Users\\Maral\\Desktop\\tp-records_gnd-ids.csv'))
+data = csv.reader(open('tp-records_gnd-ids.csv'))
 fields = data.next()
 eventdic={}
 
@@ -160,4 +160,3 @@ for row in data:
 
 
 graph.serialize(destination='UB-gnd-enrich.ttl', format="turtle")
-

--- a/gnd-persons/scripts/person_generator_GND_01.py
+++ b/gnd-persons/scripts/person_generator_GND_01.py
@@ -10,7 +10,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop\output')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 
@@ -121,4 +121,3 @@ if (u"person",u"occ",u"name",u"label") in results:
        g.add( (URIRef(jlURI), gndo.preferredNameForTheSubjectHeading , URIRef(b[u"occ"].value) ) )
 
 g.serialize(destination = 'generated_persons_GND.ttl' , format="turtle")
-

--- a/gnd-persons/scripts/person_generator_GND_02.py
+++ b/gnd-persons/scripts/person_generator_GND_02.py
@@ -10,7 +10,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop\output')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 
@@ -122,4 +122,3 @@ if (u"person",u"occ",u"name",u"label") in results:
        g.add( (URIRef(jlURI), gndo.preferredNameForTheSubjectHeading , URIRef(b[u"occ"].value) ) )
 
 g.serialize(destination = 'generated_persons_GND.ttl' , format="turtle")
-

--- a/gnd-persons/scripts/person_generator_GND_Occontology_01.py
+++ b/gnd-persons/scripts/person_generator_GND_Occontology_01.py
@@ -10,7 +10,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop\output')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 
@@ -127,4 +127,3 @@ if (u"person",u"occ",u"name",u"occname",u"occont",u"label") in results:
        g.add( (URIRef(jlURI), jl.occupation , URIRef(b[u"occont"].value) ) )
 
 g.serialize(destination = 'generated_person_GND_Occontology.ttl' , format="turtle") 
-

--- a/gnd-persons/scripts/person_generator_GND_Occontology_02.py
+++ b/gnd-persons/scripts/person_generator_GND_Occontology_02.py
@@ -10,7 +10,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop\output')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 
@@ -127,4 +127,3 @@ if (u"person",u"occ",u"name",u"occname",u"occont",u"label") in results:
        g.add( (URIRef(jlURI), jl.occupation , URIRef(b[u"occont"].value) ) )
 
 g.serialize(destination = 'generated_person_GND_Occontology.ttl' , format="turtle")
-

--- a/interlinks/scripts/JudaicaLink-interlink-01.py
+++ b/interlinks/scripts/JudaicaLink-interlink-01.py
@@ -10,7 +10,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 

--- a/interlinks/scripts/JudaicaLink-interlink-02.py
+++ b/interlinks/scripts/JudaicaLink-interlink-02.py
@@ -10,7 +10,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 

--- a/interlinks/scripts/JudaicaLink-interlink-03.py
+++ b/interlinks/scripts/JudaicaLink-interlink-03.py
@@ -10,7 +10,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML  , JSON , TURTLE
 import re
 import pprint
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 
@@ -22,7 +22,7 @@ skos = Namespace("http://www.w3.org/2004/02/skos/core#")
 owl = Namespace("http://www.w3.org/2002/07/owl#")
 
 g = Graph()
-g.parse('C:\Users\Maral\Desktop\interlinks-03.ttl', format="turtle")
+g.parse('interlinks-03.ttl', format='turtle')
 
 
 g.bind('foaf',foaf)
@@ -67,7 +67,6 @@ for item in results:
 
 
 g.serialize(destination = 'interlinks-04.ttl' , format="turtle")
-
 
 
 

--- a/interlinks/scripts/JudaicaLink-interlink-04.py
+++ b/interlinks/scripts/JudaicaLink-interlink-04.py
@@ -9,7 +9,7 @@ from SPARQLWrapper import SPARQLWrapper2, XML , RDF , JSON
 from rdflib.namespace import RDF, FOAF , SKOS ,RDFS
 import os
 
-os.chdir('C:\Users\Maral\Desktop')
+os.chdir(os.getcwd())
 
 sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
 
@@ -20,13 +20,13 @@ jl = Namespace("http://data.judaicalink.org/ontology/")
 owl = Namespace ("http://www.w3.org/2002/07/owl#")
 
 graph = Graph()
-#graph.parse('C:\Users\Maral\Desktop\interlinks-04.ttl', format="turtle")
-#graph.parse('C:\Users\Maral\Desktop\interlinks-04-enriched-01.ttl', format="turtle")
-#graph.parse('C:\Users\Maral\Desktop\interlinks-04-enriched-02.ttl', format="turtle")
-#graph.parse('C:\Users\Maral\Desktop\interlinks-04-enriched-03.ttl', format="turtle")
-#graph.parse('C:\Users\Maral\Desktop\interlinks-04-enriched-04.ttl', format="turtle")
-#graph.parse('C:\Users\Maral\Desktop\interlinks-04-enriched-05.ttl', format="turtle")
-graph.parse('C:\Users\Maral\Desktop\interlinks-04-enriched-06.ttl', format="turtle")
+#graph.parse('interlinks-04.ttl', format="turtle")
+#graph.parse('interlinks-04-enriched-01.ttl', format="turtle")
+#graph.parse('interlinks-04-enriched-02.ttl', format="turtle")
+#graph.parse('interlinks-04-enriched-03.ttl', format="turtle")
+#graph.parse('interlinks-04-enriched-04.ttl', format="turtle")
+#graph.parse('interlinks-04-enriched-05.ttl', format="turtle")
+graph.parse('interlinks-04-enriched-06.ttl', format='turtle')
 
 
 
@@ -103,7 +103,6 @@ if (u"x",u"same2") in results:
 #graph.serialize(destination='interlinks-04-enriched-05.ttl', format="turtle")
 #graph.serialize(destination='interlinks-04-enriched-06.ttl', format="turtle")
 graph.serialize(destination='interlinks-04-enriched-07.ttl', format="turtle")
-
 
 
 

--- a/nli-persons/scripts/NLI-persons-03.py
+++ b/nli-persons/scripts/NLI-persons-03.py
@@ -10,7 +10,7 @@ from rdflib.namespace import RDF, FOAF , OWL
 import json
 import os
 
-os.chdir('C:\\Users\\Maral\\Desktop')
+os.chdir(os.getcwd())
 
 graph = Graph()
 

--- a/stolpersteine/scripts/Stein-wiki-01.py
+++ b/stolpersteine/scripts/Stein-wiki-01.py
@@ -13,7 +13,7 @@ import csv
 import re
 import time
 
-os.chdir('C:\\Users\\Maral\\Desktop')
+script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
 graph = Graph()
 


### PR DESCRIPTION
## Summary
- eliminate absolute output directories in generator scripts
- switch Windows-specific paths to portable Linux ones
- drop hardcoded desktop references across utilities
- undo changes to `output_path` lines per review feedback

## Testing
- `python3 -m py_compile beacon-file/generate_beacon.py epidat/scripts/generator.py footprints/generator.py gidal/scripts/generator.py hhkeydocs/generator.py nrwbibdjg/generator.py soundscape-synagoge/scripts/generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68416204c438833096ba5e6b374b2fac