### PR TITLE
Switch to local judaicalink SPARQL

### DIFF
--- a/beacon-file/generate_beacon.py
+++ b/beacon-file/generate_beacon.py
@@ -60,7 +60,7 @@ def get_gnd_ids():
     gnd_ids = []
 
     queryString = "SELECT * WHERE { ?s ?p ?o. } LIMIT 10"
-    sparql = SPARQLWrapper("https://data.judaicalink.org/sparql/query")
+    sparql = SPARQLWrapper("http://localhost:3030/judaicalink/sparql")
 
     sparql.setQuery("""
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/bhr/Round1/scripts/BHR-vs-GND-01.py
+++ b/bhr/Round1/scripts/BHR-vs-GND-01.py
@@ -12,7 +12,7 @@ import pprint
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")

--- a/bhr/Round1/scripts/BHR-vs-JudaicaLink-01.py
+++ b/bhr/Round1/scripts/BHR-vs-JudaicaLink-01.py
@@ -12,7 +12,7 @@ import pprint
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")

--- a/bhr/Round2/scripts/Entityfacts-01.py
+++ b/bhr/Round2/scripts/Entityfacts-01.py
@@ -15,7 +15,7 @@ import time
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 graph = Graph()
 

--- a/bhr/Round2/scripts/Integrate-new-old-02.py
+++ b/bhr/Round2/scripts/Integrate-new-old-02.py
@@ -12,7 +12,7 @@ import os
 
 os.chdir(os.getcwd())
 
-#sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+#sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")
 skos = Namespace("http://www.w3.org/2004/02/skos/core#")

--- a/bhr/Round2/scripts/Integrate-new-old-03.py
+++ b/bhr/Round2/scripts/Integrate-new-old-03.py
@@ -12,7 +12,7 @@ import os
 
 os.chdir(os.getcwd())
 
-#sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+#sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")
 skos = Namespace("http://www.w3.org/2004/02/skos/core#")

--- a/bhr/Round2/scripts/Integrate-new-old-04.py
+++ b/bhr/Round2/scripts/Integrate-new-old-04.py
@@ -12,7 +12,7 @@ import os
 
 os.chdir(os.getcwd())
 
-#sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+#sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")
 skos = Namespace("http://www.w3.org/2004/02/skos/core#")

--- a/dbpedia-persons/scripts/Entityfacts-01.py
+++ b/dbpedia-persons/scripts/Entityfacts-01.py
@@ -15,7 +15,7 @@ import time
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 graph = Graph()
 

--- a/dbpedia-persons/scripts/generated_persons_DBPedia_enrich.py
+++ b/dbpedia-persons/scripts/generated_persons_DBPedia_enrich.py
@@ -11,7 +11,7 @@ import os
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")
 skos = Namespace("http://www.w3.org/2004/02/skos/core#")

--- a/entity-pages/birth_death_date_loc_selector.ipynb
+++ b/entity-pages/birth_death_date_loc_selector.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sparql = SPARQLWrapper(\"http://data.judaicalink.org/sparql/query\")\n",
+    "sparql = SPARQLWrapper(\"http://localhost:3030/judaicalink/sparql\")\n",
     "sparql.setQuery(\"\"\"\n",
     "    PREFIX jl: <http://data.judaicalink.org/ontology/>\n",
     "    PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",

--- a/entity-pages/birth_death_date_loc_selector.py
+++ b/entity-pages/birth_death_date_loc_selector.py
@@ -1,7 +1,7 @@
 import pprint, os
 from SPARQLWrapper import SPARQLWrapper, JSON
 from rdflib import Graph, URIRef, Namespace, Literal
-sparql = SPARQLWrapper("http://data.judaicalink.org/sparql/query")
+sparql = SPARQLWrapper("http://localhost:3030/judaicalink/sparql")
 sparql.setQuery("""
     PREFIX jl: <http://data.judaicalink.org/ontology/>
     PREFIX owl: <http://www.w3.org/2002/07/owl#>

--- a/entity-pages/ep_generator.md
+++ b/entity-pages/ep_generator.md
@@ -69,7 +69,7 @@ logging.info("Just set current RUN folders and loaded data structures...! Execut
 
 ```python
 logging.info("Performing queries...")
-sparql = SPARQLWrapper("http://data.judaicalink.org/sparql/query")
+sparql = SPARQLWrapper("http://localhost:3030/judaicalink/sparql")
 sparql.setQuery("""
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX owl: <http://www.w3.org/2002/07/owl#>
@@ -86,7 +86,7 @@ logging.info("Query 1: returned {} triples.".format(len(results['results']['bind
 ```
 
 ```python
-sparql = SPARQLWrapper("http://data.judaicalink.org/sparql/query")
+sparql = SPARQLWrapper("http://localhost:3030/judaicalink/sparql")
 sparql.setQuery("""
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX owl: <http://www.w3.org/2002/07/owl#>

--- a/entity-pages/label_selector.ipynb
+++ b/entity-pages/label_selector.ipynb
@@ -21,7 +21,7 @@
    "outputs": [],
    "source": [
     "# query preferred labels\n",
-    "sparql = SPARQLWrapper(\"http://data.judaicalink.org/sparql/query\")\n",
+    "sparql = SPARQLWrapper(\"http://localhost:3030/judaicalink/sparql\")\n",
     "sparql.setQuery(\"\"\"\n",
     "    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n",
     "    PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
@@ -86,7 +86,7 @@
    "outputs": [],
    "source": [
     "# query alternative labels\n",
-    "sparql = SPARQLWrapper(\"http://data.judaicalink.org/sparql/query\")\n",
+    "sparql = SPARQLWrapper(\"http://localhost:3030/judaicalink/sparql\")\n",
     "sparql.setQuery(\"\"\"\n",
     "    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n",
     "    PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",

--- a/entity-pages/label_selector.py
+++ b/entity-pages/label_selector.py
@@ -5,7 +5,7 @@ from SPARQLWrapper import SPARQLWrapper, JSON
 from rdflib import Graph, URIRef, Namespace, Literal
 from rdflib.namespace import SKOS
 # query preferred labels
-sparql = SPARQLWrapper("http://data.judaicalink.org/sparql/query")
+sparql = SPARQLWrapper("http://localhost:3030/judaicalink/sparql")
 sparql.setQuery("""
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX owl: <http://www.w3.org/2002/07/owl#>
@@ -46,7 +46,7 @@ for ep, labs in ep_to_labels.items():
         else: # take the most frequent label
             pref_labels[ep] = max(labs, key=labs.get)
 # query alternative labels
-sparql = SPARQLWrapper("http://data.judaicalink.org/sparql/query")
+sparql = SPARQLWrapper("http://localhost:3030/judaicalink/sparql")
 sparql.setQuery("""
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX owl: <http://www.w3.org/2002/07/owl#>

--- a/entity-pages/location_selector.ipynb
+++ b/entity-pages/location_selector.ipynb
@@ -19,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sparql = SPARQLWrapper(\"http://data.judaicalink.org/sparql/query\")\n",
+    "sparql = SPARQLWrapper(\"http://localhost:3030/judaicalink/sparql\")\n",
     "sparql.setQuery(\"\"\"\n",
     "    PREFIX jl: <http://data.judaicalink.org/ontology/>\n",
     "    PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",

--- a/entity-pages/location_selector.py
+++ b/entity-pages/location_selector.py
@@ -3,7 +3,7 @@
 from SPARQLWrapper import SPARQLWrapper, JSON
 from rdflib import Graph, URIRef, Namespace
 from rdflib.namespace import RDF
-sparql = SPARQLWrapper("http://data.judaicalink.org/sparql/query")
+sparql = SPARQLWrapper("http://localhost:3030/judaicalink/sparql")
 sparql.setQuery("""
     PREFIX jl: <http://data.judaicalink.org/ontology/>
     PREFIX owl: <http://www.w3.org/2002/07/owl#>

--- a/entity-pages/person_selector.ipynb
+++ b/entity-pages/person_selector.ipynb
@@ -19,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sparql = SPARQLWrapper(\"http://data.judaicalink.org/sparql/query\")\n",
+    "sparql = SPARQLWrapper(\"http://localhost:3030/judaicalink/sparql\")\n",
     "sparql.setQuery(\"\"\"\n",
     "    PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n",
     "    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",

--- a/entity-pages/person_selector.py
+++ b/entity-pages/person_selector.py
@@ -3,7 +3,7 @@
 from SPARQLWrapper import SPARQLWrapper, JSON
 from rdflib import Graph, URIRef
 from rdflib.namespace import RDF, FOAF
-sparql = SPARQLWrapper("http://data.judaicalink.org/sparql/query")
+sparql = SPARQLWrapper("http://localhost:3030/judaicalink/sparql")
 sparql.setQuery("""
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
     PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>

--- a/entity-pages/subcategorization.ipynb
+++ b/entity-pages/subcategorization.ipynb
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "# query entity pages\n",
-    "sparql = SPARQLWrapper(\"http://data.judaicalink.org/sparql/query\")\n",
+    "sparql = SPARQLWrapper(\"http://localhost:3030/judaicalink/sparql\")\n",
     "sparql.setQuery(\"\"\"\n",
     "    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n",
     "    PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",

--- a/entity-pages/subcategorization.py
+++ b/entity-pages/subcategorization.py
@@ -9,7 +9,7 @@ g = Graph()
 jl = Namespace("http://data.judaicalink.org/ontology/")
 g.bind('jl', jl)
 # query entity pages
-sparql = SPARQLWrapper("http://data.judaicalink.org/sparql/query")
+sparql = SPARQLWrapper("http://localhost:3030/judaicalink/sparql")
 sparql.setQuery("""
     PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
     PREFIX owl: <http://www.w3.org/2002/07/owl#>

--- a/fid-judaica/compactmemory/Scripts/No-GND.py
+++ b/fid-judaica/compactmemory/Scripts/No-GND.py
@@ -11,7 +11,7 @@ import os
 
 script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")

--- a/fid-judaica/compactmemory/Scripts/cm-Date-filtering.py
+++ b/fid-judaica/compactmemory/Scripts/cm-Date-filtering.py
@@ -18,7 +18,7 @@ script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
 
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")

--- a/fid-judaica/compactmemory/Scripts/compact-extarction-02.py
+++ b/fid-judaica/compactmemory/Scripts/compact-extarction-02.py
@@ -11,7 +11,7 @@ import os
 
 script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")
 skos = Namespace("http://www.w3.org/2004/02/skos/core#")

--- a/fid-judaica/freimann/scripts/Not-in-GND.py
+++ b/fid-judaica/freimann/scripts/Not-in-GND.py
@@ -10,7 +10,7 @@ import os
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")
 skos = Namespace("http://www.w3.org/2004/02/skos/core#")

--- a/fid-judaica/freimann/scripts/Tn-GNDID-01.py
+++ b/fid-judaica/freimann/scripts/Tn-GNDID-01.py
@@ -11,7 +11,7 @@ import os
 
 script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")
 skos = Namespace("http://www.w3.org/2004/02/skos/core#")

--- a/fid-judaica/freimann/scripts/Tn-GNDID-02.py
+++ b/fid-judaica/freimann/scripts/Tn-GNDID-02.py
@@ -11,7 +11,7 @@ import os
 
 script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")
 skos = Namespace("http://www.w3.org/2004/02/skos/core#")

--- a/fid-judaica/freimann/scripts/Tn-GNDID-03.py
+++ b/fid-judaica/freimann/scripts/Tn-GNDID-03.py
@@ -12,7 +12,7 @@ import os
 
 script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")
 skos = Namespace("http://www.w3.org/2004/02/skos/core#")

--- a/fid-judaica/haskala/scripts/GND-enrich-02.py
+++ b/fid-judaica/haskala/scripts/GND-enrich-02.py
@@ -11,7 +11,7 @@ import os
 
 script_dir = os.path.dirname(os.path.abspath(__file__)); os.chdir(script_dir)
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 graphuni = Graph()
 

--- a/geocoordinates/scripts/Locaion-coor-03.py
+++ b/geocoordinates/scripts/Locaion-coor-03.py
@@ -10,7 +10,7 @@ from rdflib.namespace import RDF, FOAF , SKOS ,RDFS
 import os
 from decimal import Decimal
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")
 skos = Namespace("http://www.w3.org/2004/02/skos/core#")

--- a/geocoordinates/scripts/Location-coor-02-02.py
+++ b/geocoordinates/scripts/Location-coor-02-02.py
@@ -14,7 +14,7 @@ import csv
 import re
 import unidecode
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 graph = Graph()
 

--- a/gnd-persons/scripts/Entityfacts-01.py
+++ b/gnd-persons/scripts/Entityfacts-01.py
@@ -15,7 +15,7 @@ import time
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 graph = Graph()
 

--- a/gnd-persons/scripts/Freimann-GND-enrich.py
+++ b/gnd-persons/scripts/Freimann-GND-enrich.py
@@ -11,7 +11,7 @@ import os
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")
 skos = Namespace("http://www.w3.org/2004/02/skos/core#")

--- a/gnd-persons/scripts/UB-gnd.py
+++ b/gnd-persons/scripts/UB-gnd.py
@@ -17,7 +17,7 @@ import unidecode
 os.chdir(os.getcwd())
 
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 
 graph = Graph()

--- a/gnd-persons/scripts/person_generator_GND_01.py
+++ b/gnd-persons/scripts/person_generator_GND_01.py
@@ -12,7 +12,7 @@ import pprint
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 graph = Graph()
 

--- a/gnd-persons/scripts/person_generator_GND_02.py
+++ b/gnd-persons/scripts/person_generator_GND_02.py
@@ -12,7 +12,7 @@ import pprint
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 graph = Graph()
 

--- a/gnd-persons/scripts/person_generator_GND_Occontology_01.py
+++ b/gnd-persons/scripts/person_generator_GND_Occontology_01.py
@@ -12,7 +12,7 @@ import pprint
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 graph = Graph()
 

--- a/gnd-persons/scripts/person_generator_GND_Occontology_02.py
+++ b/gnd-persons/scripts/person_generator_GND_Occontology_02.py
@@ -12,7 +12,7 @@ import pprint
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 graph = Graph()
 

--- a/haskala/scripts/GND-enrich-02.py
+++ b/haskala/scripts/GND-enrich-02.py
@@ -11,7 +11,7 @@ import os
 
 os.chdir('../output')
 
-sparql = SPARQLWrapper2("http://data.judaicalink.org/sparql/query")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 graphuni = Graph()
 

--- a/interlinks/scripts/JudaicaLink-interlink-01.py
+++ b/interlinks/scripts/JudaicaLink-interlink-01.py
@@ -12,7 +12,7 @@ import pprint
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")

--- a/interlinks/scripts/JudaicaLink-interlink-02.py
+++ b/interlinks/scripts/JudaicaLink-interlink-02.py
@@ -12,7 +12,7 @@ import pprint
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")

--- a/interlinks/scripts/JudaicaLink-interlink-03.py
+++ b/interlinks/scripts/JudaicaLink-interlink-03.py
@@ -12,7 +12,7 @@ import pprint
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")

--- a/interlinks/scripts/JudaicaLink-interlink-04.py
+++ b/interlinks/scripts/JudaicaLink-interlink-04.py
@@ -11,7 +11,7 @@ import os
 
 os.chdir(os.getcwd())
 
-sparql = SPARQLWrapper2("http://localhost:3030/Datasets/sparql")
+sparql = SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 foaf = Namespace("http://xmlns.com/foaf/0.1/")
 skos = Namespace("http://www.w3.org/2004/02/skos/core#")

--- a/interlinks/scripts/maral-kai-linking-session.ipynb
+++ b/interlinks/scripts/maral-kai-linking-session.ipynb
@@ -39,7 +39,7 @@
     "prefixes = []\n",
     "prefixes.append(('skos', 'http://www.w3.org/2004/02/skos/core#'))\n",
     "\n",
-    "sparql = sw.SPARQLWrapper2(\"http://data.judaicalink.org/sparql/query\")\n",
+    "sparql = sw.SPARQLWrapper2(\"http://localhost:3030/judaicalink/sparql\")\n",
     "\n",
     "def get_prefixes():\n",
     "    return \"\\n\".join([\"PREFIX {}: <{}>\".format(prefix, url) for prefix, url in prefixes])\n",

--- a/interlinks/scripts/maral-kai-linking-session.py
+++ b/interlinks/scripts/maral-kai-linking-session.py
@@ -4,7 +4,7 @@ import SPARQLWrapper as sw
 prefixes = []
 prefixes.append(('skos', 'http://www.w3.org/2004/02/skos/core#'))
 
-sparql = sw.SPARQLWrapper2("http://data.judaicalink.org/sparql/query")
+sparql = sw.SPARQLWrapper2("http://localhost:3030/judaicalink/sparql")
 
 def get_prefixes():
     return "\n".join(["PREFIX {}: <{}>".format(prefix, url) for prefix, url in prefixes])


### PR DESCRIPTION
## Summary
- point scripts at `http://localhost:3030/judaicalink/sparql`
- fix beacon generator to use the new endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684173e40b7c83309e4789a10a8ae5e2